### PR TITLE
Made JSON.stringify comptible with javascript JSON

### DIFF
--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -204,10 +204,10 @@ export class Str extends Value {
   }
 
   stringify(): string {
-    let escaped: string[] = [];
+    let escaped: string[] = new Array(this._str.length);
     for (let i = 0; i < this._str.length; i++) {
       const char = this._str.at(i);
-      escaped.push(this.escapeChar(char));
+      escaped[i] = this.escapeChar(char);
     }
     return `"${escaped.join('')}"`;
   }

--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -183,15 +183,23 @@ export abstract class Value {
 }
 
 export class Str extends Value {
-  private escape_map:Map<string, string> = new Map<string, string>();
 
   constructor(public _str: string) {
     super();
-    const from: Array<string> = ['"', "\\", "\b", "\n", "\r", "\t", '\f', '\v'];
-    const to: Array<string> = ['\\"', "\\\\", "\\b", "\\n", "\\r", "\\t", "\\f", "\\u000b"];
-    
-    for(let i=0; i < from.length;i++){
-      this.escape_map.set(from[i], to[i]);
+  }
+
+  private escapeChar(char:string):string{
+    const charCode:i32 = char.charCodeAt(0);
+    switch(charCode){
+      case 0x22: return '\\"';
+      case 0x5C: return "\\\\";
+      case 0x08: return "\\b";
+      case 0x0A: return "\\n";
+      case 0x0D: return "\\r";
+      case 0x09: return "\\t";
+      case 0x0C: return "\\f";
+      case 0x0B: return "\\u000b";
+      default: return char;
     }
   }
 
@@ -199,12 +207,7 @@ export class Str extends Value {
     let escaped: string[] = [];
     for (let i = 0; i < this._str.length; i++) {
       const char = this._str.at(i);
-
-      if ( this.escape_map.has(char) ) {
-        escaped.push(this.escape_map.get(char));
-      }else{
-        escaped.push(char);
-      }
+      escaped.push(this.escapeChar(char));
     }
     return `"${escaped.join('')}"`;
   }

--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -188,9 +188,9 @@ export class Str extends Value {
     super();
   }
 
-  private escapeChar(char:string):string{
-    const charCode:i32 = char.charCodeAt(0);
-    switch(charCode){
+  private escapeChar(char: string): string {
+    const charCode = char.charCodeAt(0);
+    switch (charCode) {
       case 0x22: return '\\"';
       case 0x5C: return "\\\\";
       case 0x08: return "\\b";

--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -182,32 +182,32 @@ export abstract class Value {
   }
 }
 
+function escapeChar(char: string): string {
+  const charCode = char.charCodeAt(0);
+  switch (charCode) {
+    case 0x22: return '\\"';
+    case 0x5C: return "\\\\";
+    case 0x08: return "\\b";
+    case 0x0A: return "\\n";
+    case 0x0D: return "\\r";
+    case 0x09: return "\\t";
+    case 0x0C: return "\\f";
+    case 0x0B: return "\\u000b";
+    default: return char;
+  }
+}
+
 export class Str extends Value {
 
   constructor(public _str: string) {
     super();
   }
 
-  private escapeChar(char: string): string {
-    const charCode = char.charCodeAt(0);
-    switch (charCode) {
-      case 0x22: return '\\"';
-      case 0x5C: return "\\\\";
-      case 0x08: return "\\b";
-      case 0x0A: return "\\n";
-      case 0x0D: return "\\r";
-      case 0x09: return "\\t";
-      case 0x0C: return "\\f";
-      case 0x0B: return "\\u000b";
-      default: return char;
-    }
-  }
-
   stringify(): string {
     let escaped: string[] = new Array(this._str.length);
     for (let i = 0; i < this._str.length; i++) {
       const char = this._str.at(i);
-      escaped[i] = this.escapeChar(char);
+      escaped[i] = escapeChar(char);
     }
     return `"${escaped.join('')}"`;
   }

--- a/assembly/JSON.ts
+++ b/assembly/JSON.ts
@@ -183,24 +183,30 @@ export abstract class Value {
 }
 
 export class Str extends Value {
+  private escape_map:Map<string, string> = new Map<string, string>();
+
   constructor(public _str: string) {
     super();
+    const from: Array<string> = ['"', "\\", "\b", "\n", "\r", "\t", '\f', '\v'];
+    const to: Array<string> = ['\\"', "\\\\", "\\b", "\\n", "\\r", "\\t", "\\f", "\\u000b"];
+    
+    for(let i=0; i < from.length;i++){
+      this.escape_map.set(from[i], to[i]);
+    }
   }
 
   stringify(): string {
-    let escaped: i32[] = [];
+    let escaped: string[] = [];
     for (let i = 0; i < this._str.length; i++) {
-      const charCode = this._str.charCodeAt(i);
-      if (
-        charCode == 0x22 || // "    quotation mark  U+0022
-        charCode == 0x5C || // \    reverse solidus U+005C
-        charCode < 0x20 // control characters
-      ) {
-        escaped.push(0x5c); // add a reverse solidus (backslash) to escape reserved chars 
+      const char = this._str.at(i);
+
+      if ( this.escape_map.has(char) ) {
+        escaped.push(this.escape_map.get(char));
+      }else{
+        escaped.push(char);
       }
-      escaped.push(charCode);
     }
-    return "\"" + String.fromCharCodes(escaped) + "\"";
+    return `"${escaped.join('')}"`;
   }
 
   toString(): string {

--- a/assembly/__tests__/string_escape.spec.ts
+++ b/assembly/__tests__/string_escape.spec.ts
@@ -22,7 +22,9 @@ describe('Escaped characters', () => {
 
   it('Escapes quotes and backslashes', () => {
     const strings = ['"', '\\', '"\\"', '\\"\\"'];
+    // Computed using javascript's JSON as implemented in mozilla firefox 90.0 (64-bit)
     const expected = ["\"\\\"\"", "\"\\\\\"", "\"\\\"\\\\\\\"\"", "\"\\\\\\\"\\\\\\\"\""];
+    
     for(let i=0; i<strings.length; i++){
       const jsonStr = new JSON.Str(strings[i]);
       expect(jsonStr.stringify()).toBe(expected[i]);
@@ -31,6 +33,7 @@ describe('Escaped characters', () => {
 
   it('Escapes control characters', () => {
     const strings = ['\n', '\r', '\r\n', '\b', '\f', '\t', '\v', '\b\f\t\v\r'];
+    // Computed using javascript's JSON as implemented in mozilla firefox 90.0 (64-bit)
     const expected = ["\"\\n\"","\"\\r\"","\"\\r\\n\"","\"\\b\"","\"\\f\"","\"\\t\"","\"\\u000b\"","\"\\b\\f\\t\\u000b\\r\""];
 
     for(let i=0; i<strings.length; i++){

--- a/assembly/__tests__/string_escape.spec.ts
+++ b/assembly/__tests__/string_escape.spec.ts
@@ -16,38 +16,26 @@ describe('Escaped characters', () => {
     ];
     strings.forEach((str) => {
       const jsonStr = new JSON.Str(str);
-      expect(jsonStr.stringify()).toBe('"' + str + '"');
+      expect(jsonStr.stringify()).toBe(`"${str}"`);
     });
   });
+
   it('Escapes quotes and backslashes', () => {
     const strings = ['"', '\\', '"\\"', '\\"\\"'];
-    strings.forEach((str) => {
-      const jsonStr = new JSON.Str(str);
-      expect(jsonStr.stringify()).toBe('"' + escaped(str) + '"');
-    });
+    const expected = ["\"\\\"\"", "\"\\\\\"", "\"\\\"\\\\\\\"\"", "\"\\\\\\\"\\\\\\\"\""];
+    for(let i=0; i<strings.length; i++){
+      const jsonStr = new JSON.Str(strings[i]);
+      expect(jsonStr.stringify()).toBe(expected[i]);
+    }
   });
+
   it('Escapes control characters', () => {
     const strings = ['\n', '\r', '\r\n', '\b', '\f', '\t', '\v', '\b\f\t\v\r'];
-    strings.forEach((str) => {
-      const jsonStr = new JSON.Str(str);
-      expect(jsonStr.stringify()).toBe('"' + escaped(str) + '"');
-    });
+    const expected = ["\"\\n\"","\"\\r\"","\"\\r\\n\"","\"\\b\"","\"\\f\"","\"\\t\"","\"\\u000b\"","\"\\b\\f\\t\\u000b\\r\""];
+
+    for(let i=0; i<strings.length; i++){
+      const jsonStr = new JSON.Str(strings[i]);
+      expect(jsonStr.stringify()).toBe(expected[i]);
+    }
   });
 });
-
-function escaped(str: string): string {
-  const escapedChars: i32[] = [];
-  for (let i = 0; i < str.length; i++) {
-    const charCode = str.charCodeAt(i);
-    if (
-      charCode < 0x20 || // control characters
-      charCode == 0x22 || // double quote (")
-      charCode == 0x5c
-    ) {
-      // backslash / reverse solidus (\)
-      escapedChars.push(0x5c);
-    }
-    escapedChars.push(charCode);
-  }
-  return String.fromCharCodes(escapedChars);
-}


### PR DESCRIPTION
The current JSON.stringify method escaped characters in a way that
was NOT compatible with the current javascript JSON implementation.
For example, the string single-character "\n" was being translated
into:
```
"\"\
\""
```
Instead of being stringifyed as: `"\"\n\""`. This is because the
character \n was being added, instead of adding an "n" preceeded
by an "\\".

This commit fixes such problem by using a direct mapping from
escapable characters into their escaped stringified version.